### PR TITLE
Create pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "torch"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Currently the project is not installable with the current pip version using build isolation.

A minimal pyproject.toml file fulfills the requirements of most build processes.