### PR TITLE
Fix: cooperative_groups.h not found on AMD Instinct GPUs - use CUDAExtension for ROCm/HIP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def configure_cuda():
             compiler_args["nvcc"].extend(fallback_archs)
             detected_arch = "multiple architectures"
 
-    return CppExtension, "ssim.cu", "fused_ssim_cuda", compiler_args, [], detected_arch
+    return CUDAExtension, "ssim.cu", "fused_ssim_cuda", compiler_args, [], detected_arch
 
 
 def configure_mps():


### PR DESCRIPTION
Issue:  Seeing cooperative_groups.h not found error when installing fused-ssim on AMD Instinct GPUs (Screenshot below for your reference)
<img width="1342" height="363" alt="image" src="https://github.com/user-attachments/assets/0025b9bd-66b8-404e-8cdc-4e77cb920870" />

Rootcause: The setup.py was using `CppExtension` which invokes the standard C++ compiler (g++/clang++) instead of the HIP compiler (`hipcc`). This resulted in:
- Missing HIP/CUDA header include paths
- No device code compilation support
- Inability to find GPU-specific headers like `cooperative_groups.h`

Fix: Changed CppExtension to CUDAExtension so that Pytorch can handle both CUDA and HIP compilation automatically. PyTorch now automatically detects ROCm/HIP and uses hipcc with proper include paths.