### PR TITLE
Add fused L1 SSIM loss and backward functions

### DIFF
--- a/ext.cpp
+++ b/ext.cpp
@@ -4,4 +4,6 @@
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("fusedssim", &fusedssim);
   m.def("fusedssim_backward", &fusedssim_backward);
+  m.def("fusedl1ssim_loss", &fusedl1ssim_loss);
+  m.def("fusedl1ssim_loss_backward", &fusedl1ssim_loss_backward);
 }

--- a/fused_ssim/__init__.py
+++ b/fused_ssim/__init__.py
@@ -4,6 +4,7 @@ import torch
 
 if torch.cuda.is_available():
     from fused_ssim_cuda import fusedssim, fusedssim_backward
+    from fused_ssim_cuda import fusedl1ssim_loss, fusedl1ssim_loss_backward
 elif torch.mps.is_available():
     from fused_ssim_mps import fusedssim, fusedssim_backward
 elif hasattr(torch, 'xpu') and torch.xpu.is_available():
@@ -46,4 +47,44 @@ def fused_ssim(img1, img2, padding="same", train=True):
 
     img1 = img1.contiguous()
     map = FusedSSIMMap.apply(C1, C2, img1, img2, padding, train)
+    return map.mean()
+
+
+class FusedL1SSIMLossMap(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, ssim_weight, C1, C2, img1, img2, padding="same", train=True):
+        if not torch.cuda.is_available():
+            raise RuntimeError("FusedL1SSIMLossMap only supports CUDA")
+
+        l1_ssim_loss_map, dm_dmu1, dm_dsigma1_sq, dm_dsigma12 = fusedl1ssim_loss(ssim_weight, C1, C2, img1, img2, train)
+        if padding == "valid":
+            l1_ssim_loss_map = l1_ssim_loss_map[:, :, 5:-5, 5:-5]
+        ctx.save_for_backward(img1.detach(), img2, dm_dmu1, dm_dsigma1_sq, dm_dsigma12)
+        ctx.ssim_weight = ssim_weight
+        ctx.C1 = C1
+        ctx.C2 = C2
+        ctx.padding = padding
+        return l1_ssim_loss_map
+
+    @staticmethod
+    def backward(ctx, opt_grad):
+        if not torch.cuda.is_available():
+            raise RuntimeError("FusedL1SSIMLossMap only supports CUDA")
+
+        img1, img2, dm_dmu1, dm_dsigma1_sq, dm_dsigma12 = ctx.saved_tensors
+        ssim_weight, C1, C2, padding = ctx.ssim_weight, ctx.C1, ctx.C2, ctx.padding
+        dL_dmap = opt_grad
+        if padding == "valid":
+            dL_dmap = torch.zeros_like(img1)
+            dL_dmap[:, :, 5:-5, 5:-5] = opt_grad
+        grad = fusedl1ssim_loss_backward(ssim_weight, C1, C2, img1, img2, dL_dmap, dm_dmu1, dm_dsigma1_sq, dm_dsigma12)
+        return None, None, None, grad, None, None, None
+
+def fused_l1_ssim_loss(img1, img2, ssim_weight=0.2, padding="same", train=True):
+    C1 = 0.01 ** 2
+    C2 = 0.03 ** 2
+
+    assert padding in allowed_padding
+
+    map = FusedL1SSIMLossMap.apply(ssim_weight, C1, C2, img1, img2, padding, train)
     return map.mean()

--- a/ssim.cu
+++ b/ssim.cu
@@ -29,6 +29,7 @@ __constant__ float cGauss[11] = {
 #define BLOCK_X 16
 #define BLOCK_Y 16
 #define HALO    5
+#define HALO2   HALO * 2
 
 #define SHARED_X (BLOCK_X + 2 * HALO)
 #define SHARED_Y (BLOCK_Y + 2 * HALO)
@@ -508,6 +509,430 @@ fusedssim_backward(
         img2.contiguous().data_ptr<float>(),
         dL_dmap.contiguous().data_ptr<float>(),
         dL_dimg1.data_ptr<float>(),
+        dm_dmu1.contiguous().data_ptr<float>(),
+        dm_dsigma1_sq.contiguous().data_ptr<float>(),
+        dm_dsigma12.contiguous().data_ptr<float>()
+    );
+
+    return dL_dimg1;
+}
+
+// ------------------------------------------
+// Forward Kernel: Fused L1 + SSIM loss
+//  - Two-pass convolution to get mu1, mu2,
+//    sigma1_sq, sigma2_sq, sigma12, etc.
+//  - Writes final L1 + SSIM loss map to ssim_loss_map
+//  - Optionally writes partial derivatives
+//    to dm_dmu1, dm_dsigma1_sq, dm_dsigma12
+// ------------------------------------------
+__global__ void fusedl1ssim_lossCUDA(
+    float ssim_weight,
+    int H,
+    int W,
+    int CH,
+    float C1,
+    float C2,
+    const float* __restrict__ img1,
+    const float* __restrict__ img2,
+    float* __restrict__ l1_ssim_loss_map,
+    float* __restrict__ dm_dmu1,
+    float* __restrict__ dm_dsigma1_sq,
+    float* __restrict__ dm_dsigma12
+) {
+    auto block = cg::this_thread_block();
+    const int bIdx   = block.group_index().z;  // batch index
+    const int pix_y  = block.group_index().y * BLOCK_Y + block.thread_index().y;
+    const int pix_x  = block.group_index().x * BLOCK_X + block.thread_index().x;
+    const int pix_id = pix_y * W + pix_x;
+    const int num_pix = H * W;
+
+    // Shared memory for the tile (img1, img2)
+    __shared__ float sTile[SHARED_Y][SHARED_X][2];
+    // After horizontal pass, store partial sums here
+    // xconv[y][x] -> (sumX, sumX^2, sumY, sumY^2, sumXY)
+    __shared__ float xconv[CONV_Y][CONV_X][5];
+
+    // Each block processes B x C sub-batches. We loop over channels:
+    for (int c = 0; c < CH; ++c) {
+        // ------------------------------------------------------------
+        // 1) Load (img1, img2) tile + halo into shared memory
+        // ------------------------------------------------------------
+        {
+            const int tileSize = SHARED_Y * SHARED_X;
+            const int threads = BLOCK_X * BLOCK_Y;
+            const int steps = (tileSize + threads - 1) / threads;
+
+            const int tileStartY = block.group_index().y * BLOCK_Y;
+            const int tileStartX = block.group_index().x * BLOCK_X;
+
+            for (int s = 0; s < steps; ++s) {
+                int tid = s * threads + block.thread_rank();
+                if (tid < tileSize) {
+                    int local_y = tid / SHARED_X;
+                    int local_x = tid % SHARED_X;
+                    int gy = tileStartY + local_y - HALO;
+                    int gx = tileStartX + local_x - HALO;
+
+                    float X = get_pix_value(img1, bIdx, c, gy, gx, CH, H, W);
+                    float Y = get_pix_value(img2, bIdx, c, gy, gx, CH, H, W);
+
+                    sTile[local_y][local_x][0] = X;
+                    sTile[local_y][local_x][1] = Y;
+                }
+            }
+        }
+        block.sync();
+
+        float l1_loss = fabs(
+            sTile[block.thread_index().y + HALO][block.thread_index().x + HALO][0] - 
+            sTile[block.thread_index().y + HALO][block.thread_index().x + HALO][1]);
+
+        // ------------------------------------------------------------
+        // 2) Horizontal convolution (11x1) in shared memory
+        //    We'll accumulate symmetrical pairs around center.
+        // ------------------------------------------------------------
+        {
+            int ly = threadIdx.y;
+            int lx = threadIdx.x + HALO;  // skip left halo
+
+            float sumX   = 0.f;
+            float sumX2  = 0.f;
+            float sumY   = 0.f;
+            float sumY2  = 0.f;
+            float sumXY  = 0.f;
+
+            // #pragma unroll for those 5 pairs
+#pragma unroll
+            for (int d = 0; d <= HALO2; ++d) {
+                float w = cGauss[d];
+                float x = sTile[ly][lx + d - HALO][0];
+                float y = sTile[ly][lx + d - HALO][1];
+
+                sumX  += x * w;
+                sumX2 += (x * x) * w;
+                sumY  += y * w;
+                sumY2 += (y * y) * w;
+                sumXY += (x * y) * w;
+            }
+           
+            // Write out partial sums
+            xconv[ly][threadIdx.x][0] = sumX;
+            xconv[ly][threadIdx.x][1] = sumX2;
+            xconv[ly][threadIdx.x][2] = sumY;
+            xconv[ly][threadIdx.x][3] = sumY2;
+            xconv[ly][threadIdx.x][4] = sumXY;
+
+            // Possibly handle second row in same warp
+            int ly2 = ly + BLOCK_Y;
+            if (ly2 < CONV_Y) {
+                sumX   = 0.f; sumX2  = 0.f;
+                sumY   = 0.f; sumY2  = 0.f;
+                sumXY  = 0.f;
+
+#pragma unroll
+                for (int d = 0; d <= HALO2; ++d) {
+                    float w = cGauss[d];
+                    float x = sTile[ly2][lx + d - HALO][0];
+                    float y = sTile[ly2][lx + d - HALO][1];
+
+                    sumX  += x * w;
+                    sumX2 += (x * x) * w;
+                    sumY  += y * w;
+                    sumY2 += (y * y) * w;
+                    sumXY += (x * y) * w;
+                }
+                xconv[ly2][threadIdx.x][0] = sumX;
+                xconv[ly2][threadIdx.x][1] = sumX2;
+                xconv[ly2][threadIdx.x][2] = sumY;
+                xconv[ly2][threadIdx.x][3] = sumY2;
+                xconv[ly2][threadIdx.x][4] = sumXY;
+            }
+        }
+        block.sync();
+
+        // ------------------------------------------------------------
+        // 3) Vertical convolution (1x11) + final SSIM
+        // ------------------------------------------------------------
+        {
+            int ly = threadIdx.y + HALO;
+            int lx = threadIdx.x;
+
+            float out0 = 0.f, out1 = 0.f, out2 = 0.f, out3 = 0.f, out4 = 0.f;
+
+#pragma unroll
+            for (int d = 0; d <= HALO2; ++d) {
+                float w = cGauss[d];
+                float* v = xconv[ly + d - HALO][lx];
+                out0 += v[0] * w;
+                out1 += v[1] * w;
+                out2 += v[2] * w;
+                out3 += v[3] * w;
+                out4 += v[4] * w;
+            }
+
+            if (pix_x < W && pix_y < H) {
+                float mu1 = out0;
+                float mu2 = out2;
+                float mu1_sq = mu1 * mu1;
+                float mu2_sq = mu2 * mu2;
+
+                float sigma1_sq = out1 - mu1_sq;
+                float sigma2_sq = out3 - mu2_sq;
+                float sigma12   = out4 - mu1 * mu2;
+
+                float A = mu1_sq + mu2_sq + C1;
+                float B = sigma1_sq + sigma2_sq + C2;
+                float C_ = 2.f * mu1 * mu2 + C1;
+                float D_ = 2.f * sigma12 + C2;
+
+                float val = (C_ * D_) / (A * B);
+
+                int global_idx = bIdx * CH * num_pix + c * num_pix + pix_id;
+                l1_ssim_loss_map[global_idx] = ssim_weight * (1.0f - val) + (1.0f - ssim_weight) * l1_loss;
+
+                if (dm_dmu1) {
+                    // partial derivatives
+                    float d_m_dmu1 = (
+                        (mu2 * 2.f * D_) / (A * B)
+                        - (mu2 * 2.f * C_) / (A * B)
+                        - (mu1 * 2.f * C_ * D_) / (A * A * B)
+                        + (mu1 * 2.f * C_ * D_) / (A * B * B)
+                    );
+                    float d_m_dsigma1_sq = (-C_ * D_) / (A * B * B);
+                    float d_m_dsigma12   = (2.f * C_) / (A * B);
+
+                    dm_dmu1[global_idx]       = d_m_dmu1;
+                    dm_dsigma1_sq[global_idx] = d_m_dsigma1_sq;
+                    dm_dsigma12[global_idx]   = d_m_dsigma12;
+                }
+            }
+        }
+    }
+}
+
+// ------------------------------------------
+// Backward Kernel: Apply chain rule to get
+//    dL/d(img1) from partial derivatives
+//    (dm_dmu1, dm_dsigma1_sq, dm_dsigma12)
+//    and dL/dmap (the gradient from above).
+// ------------------------------------------
+__global__ void fusedl1ssim_loss_backwardCUDA(
+    float ssim_weight,
+    int H,
+    int W,
+    int CH,
+    float C1,
+    float C2,
+    const float* __restrict__ img1,
+    const float* __restrict__ img2,
+    const float* __restrict__ dL_dmap,
+    float* __restrict__ dL_dimg1,
+    const float* __restrict__ dm_dmu1,
+    const float* __restrict__ dm_dsigma1_sq,
+    const float* __restrict__ dm_dsigma12
+) {
+    auto block = cg::this_thread_block();
+
+    const int pix_y  = block.group_index().y * BLOCK_Y + block.thread_index().y;
+    const int pix_x  = block.group_index().x * BLOCK_X + block.thread_index().x;
+    const int pix_id = pix_y * W + pix_x;
+    const int num_pix = H * W;
+    const int bIdx   = block.group_index().z;
+
+    // Shared memory for the fused data:
+    // [0]: dm_dmu1*dL, [1]: dm_dsigma1_sq*dL, [2]: dm_dsigma12*dL
+    __shared__ float sData[SHARED_Y][SHARED_X][3];
+    __shared__ float sScratch[CONV_Y][CONV_X][3];
+
+    for (int c = 0; c < CH; ++c) {
+        float p1 = 0.f, p2 = 0.f;
+        if (pix_x < W && pix_y < H) {
+            p1 = get_pix_value(img1, bIdx, c, pix_y, pix_x, CH, H, W);
+            p2 = get_pix_value(img2, bIdx, c, pix_y, pix_x, CH, H, W);
+        }
+
+        // (1) Load + fuse multiplication
+        {
+            const int start_y = block.group_index().y * BLOCK_Y;
+            const int start_x = block.group_index().x * BLOCK_X;
+
+            int tid = threadIdx.y * blockDim.x + threadIdx.x;
+            int warp_id = tid / 32;
+            int lane_id = tid % 32;
+            int totalThreads = BLOCK_X * BLOCK_Y;
+            int num_warps = (totalThreads + 31) / 32;
+
+            for (int row = warp_id; row < SHARED_Y; row += num_warps) {
+                int gy = start_y + row - HALO;
+                for (int col = lane_id; col < SHARED_X; col += 32) {
+                    int gx = start_x + col - HALO;
+
+                    float chain = get_pix_value(dL_dmap,      bIdx, c, gy, gx, CH, H, W);
+                    float vmu   = get_pix_value(dm_dmu1,      bIdx, c, gy, gx, CH, H, W);
+                    float vs1   = get_pix_value(dm_dsigma1_sq,bIdx, c, gy, gx, CH, H, W);
+                    float vs12  = get_pix_value(dm_dsigma12,  bIdx, c, gy, gx, CH, H, W);
+
+                    // dm_dmu1 etc. store d(SSIM)/d(mu1); need to multiply by d(loss)/d(SSIM) = -ssim_weight
+                    // Then multiply by upstream gradient chain = dL/d(loss_map)
+                    sData[row][col][0] = -ssim_weight * vmu  * chain;
+                    sData[row][col][1] = -ssim_weight * vs1  * chain;
+                    sData[row][col][2] = -ssim_weight * vs12 * chain;
+                }
+            }
+        }
+        block.sync();
+
+        // (2) Horizontal pass
+        {
+            int ly = threadIdx.y;
+            int lx = threadIdx.x + HALO;
+
+            for (int pass = 0; pass < 2; ++pass) {
+                int yy = ly + pass * BLOCK_Y;
+                if (yy < CONV_Y) {
+                    float accum0 = 0.f, accum1 = 0.f, accum2 = 0.f;
+
+#pragma unroll
+                    for (int d = 0; d <= HALO2; ++d) {
+                        float w = cGauss[d];
+                        float v0  = sData[yy][lx + d - HALO][0];
+                        float v1  = sData[yy][lx + d - HALO][1];
+                        float v2  = sData[yy][lx + d - HALO][2];
+
+                        accum0 += v0 * w;
+                        accum1 += v1 * w;
+                        accum2 += v2 * w;
+                    }
+
+                    sScratch[yy][threadIdx.x][0] = accum0;
+                    sScratch[yy][threadIdx.x][1] = accum1;
+                    sScratch[yy][threadIdx.x][2] = accum2;
+                }
+            }
+        }
+        block.sync();
+
+        // (3) Vertical pass -> finalize dL/d(img1)
+        if (pix_x < W && pix_y < H) {
+            int ly = threadIdx.y + HALO;
+            int lx = threadIdx.x;
+
+            float sum0 = 0.f, sum1 = 0.f, sum2 = 0.f;
+
+#pragma unroll
+            for (int d = 0; d <= HALO2; ++d) {
+                float w = cGauss[d];
+                float* v = sScratch[ly + d - HALO][lx];
+
+                sum0 += v[0] * w;
+                sum1 += v[1] * w;
+                sum2 += v[2] * w;
+            }
+            
+            // final accumulation
+            // SSIM gradient (already contains ssim_weight and upstream gradient chain)
+            float grad_ssim = sum0 + (2.f * p1) * sum1 + (p2) * sum2;
+
+            int out_idx = bIdx * CH * num_pix + c * num_pix + pix_id;
+
+            // L1 gradient (needs to be multiplied by weight and upstream gradient)
+            float chain_local = get_pix_value(dL_dmap, bIdx, c, pix_y, pix_x, CH, H, W);
+            float sign_grad = (p1 == p2) ? 0.0f : copysignf(1.0f, p1 - p2);
+            float grad_l1 = (1.0f - ssim_weight) * sign_grad * chain_local;
+
+            // combine two parts of gradient
+            dL_dimg1[out_idx] = grad_ssim + grad_l1;
+        }
+        block.sync();
+    }
+}
+
+// ------------------------------------------
+// PyTorch Interface (Forward)
+//   Returns (ssim_map, dm_dmu1, dm_dsigma1_sq, dm_dsigma12).
+//   If train=false, derivative Tensors are empty.
+// ------------------------------------------
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+fusedl1ssim_loss(
+    float ssim_weight,
+    float C1,
+    float C2,
+    torch::Tensor &img1,
+    torch::Tensor &img2,
+    bool train
+) {
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(img1));
+    int B  = img1.size(0);
+    int CH = img1.size(1);
+    int H  = img1.size(2);
+    int W  = img1.size(3);
+
+    // Launch config
+    dim3 grid((W + BLOCK_X - 1) / BLOCK_X,
+              (H + BLOCK_Y - 1) / BLOCK_Y,
+              B);
+    dim3 block(BLOCK_X, BLOCK_Y);
+
+    // Output SSIM map
+    auto ssim_loss_map = torch::zeros_like(img1, img1.options()).contiguous();
+
+    // Optionally allocate derivative Tensors
+    auto dm_dmu1       = train ? torch::zeros_like(img1) : torch::empty({0}, img1.options());
+    auto dm_dsigma1_sq = train ? torch::zeros_like(img1) : torch::empty({0}, img1.options());
+    auto dm_dsigma12   = train ? torch::zeros_like(img1) : torch::empty({0}, img1.options());
+
+    fusedl1ssim_lossCUDA<<<grid, block>>>(
+        ssim_weight,
+        H, W, CH, C1, C2,
+        img1.contiguous().data_ptr<float>(),
+        img2.contiguous().data_ptr<float>(),
+        ssim_loss_map.contiguous().data_ptr<float>(),
+        train ? dm_dmu1.contiguous().data_ptr<float>()       : nullptr,
+        train ? dm_dsigma1_sq.contiguous().data_ptr<float>() : nullptr,
+        train ? dm_dsigma12.contiguous().data_ptr<float>()   : nullptr
+    );
+
+    return std::make_tuple(ssim_loss_map, dm_dmu1, dm_dsigma1_sq, dm_dsigma12);
+}
+
+// ------------------------------------------
+// PyTorch Interface (Backward)
+//   Takes the gradient wrt the SSIM map and
+//   the partial derivatives from forward;
+//   returns dL/d(img1).
+// ------------------------------------------
+torch::Tensor
+fusedl1ssim_loss_backward(
+    float ssim_weight,
+    float C1,
+    float C2,
+    torch::Tensor &img1,
+    torch::Tensor &img2,
+    torch::Tensor &dL_dmap,
+    torch::Tensor &dm_dmu1,
+    torch::Tensor &dm_dsigma1_sq,
+    torch::Tensor &dm_dsigma12
+) {
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(img1));
+    int B  = img1.size(0);
+    int CH = img1.size(1);
+    int H  = img1.size(2);
+    int W  = img1.size(3);
+
+    auto dL_dimg1 = torch::zeros_like(img1);
+
+    dim3 grid((W + BLOCK_X - 1) / BLOCK_X,
+              (H + BLOCK_Y - 1) / BLOCK_Y,
+              B);
+    dim3 block(BLOCK_X, BLOCK_Y);
+
+    fusedl1ssim_loss_backwardCUDA<<<grid, block>>>(
+        ssim_weight,
+        H, W, CH, C1, C2,
+        img1.contiguous().data_ptr<float>(),
+        img2.contiguous().data_ptr<float>(),
+        dL_dmap.contiguous().data_ptr<float>(),
+        dL_dimg1.contiguous().data_ptr<float>(),
         dm_dmu1.contiguous().data_ptr<float>(),
         dm_dsigma1_sq.contiguous().data_ptr<float>(),
         dm_dsigma12.contiguous().data_ptr<float>()

--- a/ssim.h
+++ b/ssim.h
@@ -24,3 +24,26 @@ fusedssim_backward(
     torch::Tensor &dm_dsigma1_sq,
     torch::Tensor &dm_dsigma12
 );
+
+std::tuple<torch::Tensor,torch::Tensor,torch::Tensor,torch::Tensor>
+fusedl1ssim_loss(
+    float ssim_weight,
+    float C1,
+    float C2,
+    torch::Tensor &img1,
+    torch::Tensor &img2,
+    bool train
+);
+
+torch::Tensor
+fusedl1ssim_loss_backward(
+    float ssim_weight,
+    float C1,
+    float C2,
+    torch::Tensor &img1,
+    torch::Tensor &img2,
+    torch::Tensor &dL_dmap,
+    torch::Tensor &dm_dmu1,
+    torch::Tensor &dm_dsigma1_sq,
+    torch::Tensor &dm_dsigma12
+);

--- a/tests/test_fused_l1_ssim_loss.py
+++ b/tests/test_fused_l1_ssim_loss.py
@@ -1,0 +1,84 @@
+import torch
+from fused_ssim import fused_l1_ssim_loss, fused_ssim
+import time
+
+ssim_weight = 0.2
+image_shape = [3, 1080, 1920]
+
+
+def l1_loss(network_output, gt):
+    return torch.abs((network_output - gt)).mean()
+
+
+def l1_ssim_map_loss(image, gt_image, ssim_weight):
+    Ll1 = l1_loss(image, gt_image)
+    ssim_value = fused_ssim(image.unsqueeze(0), gt_image.unsqueeze(0))
+    loss = (1.0 - ssim_weight) * Ll1 + ssim_weight * (1.0 - ssim_value)
+    loss.backward()
+    return loss, image.grad.clone()
+
+
+def fused_l1_ssim_loss_map(image, gt_image, ssim_weight):
+    loss = fused_l1_ssim_loss(image.unsqueeze(0), gt_image.unsqueeze(0), ssim_weight)
+    loss.backward()
+    return loss, image.grad.clone()
+
+
+def test_fused_l1_ssim_loss():
+    # generate test data
+    gt_image_data = torch.rand(image_shape, device="cuda")
+    image_data = torch.rand(image_shape, device="cuda")
+
+    # 1st result: before version
+    image1 = image_data.clone().requires_grad_(True)
+    gt_image1 = gt_image_data.clone()
+    before_loss, before_grad = l1_ssim_map_loss(image1, gt_image1, ssim_weight)
+
+    # 2nd result: after version, using the same data but different tensor
+    image2 = image_data.clone().requires_grad_(True)
+    gt_image2 = gt_image_data.clone()
+    after_loss, after_grad = fused_l1_ssim_loss_map(image2, gt_image2, ssim_weight)
+
+    assert torch.isclose(before_loss, after_loss)
+    assert torch.isclose(before_grad, after_grad).all()
+
+
+def benchmark_fused_l1_ssim_loss():
+    print("benchmarking with shape", image_shape)
+
+    gt_image = torch.rand(image_shape, device="cuda")
+    image = torch.rand(image_shape, device="cuda").requires_grad_(True)
+
+    iterations = 100
+    begin = time.time()
+    for _ in range(iterations):
+        Ll1 = l1_loss(image, gt_image)
+        ssim_value = fused_ssim(image.unsqueeze(0), gt_image.unsqueeze(0))
+        loss = (1.0 - ssim_weight) * Ll1 + ssim_weight * (1.0 - ssim_value)
+        loss.backward()
+    torch.cuda.synchronize()
+    end = time.time()
+    time_forward_backward_before = (end - begin) / iterations * 1000
+    print(
+        "l1 + fused_ssim Time (forward + backward):", time_forward_backward_before, "ms"
+    )
+
+    begin = time.time()
+    for _ in range(iterations):
+        loss = fused_l1_ssim_loss(
+            image.unsqueeze(0), gt_image.unsqueeze(0), ssim_weight
+        )
+        loss.backward()
+    torch.cuda.synchronize()
+    end = time.time()
+    time_forward_backward_after = (end - begin) / iterations * 1000
+    print(
+        f"fused_l1_ssim_loss Time (forward + backward): {time_forward_backward_after} ms ({(time_forward_backward_before - time_forward_backward_after) / time_forward_backward_before * 100:.2f}% faster)"
+    )
+
+
+if __name__ == "__main__":
+    for _ in range(100):
+        test_fused_l1_ssim_loss()
+
+    benchmark_fused_l1_ssim_loss()


### PR DESCRIPTION
This PR adds a new operator `fused_l1_ssim_loss`, in a lot of projects, especially 3D Gaussian Splatting (3DGS), a very common loss function is a combination of L1 and SSIM, usually calculated like this:

```
loss = (1.0 - alpha) * L1_loss + alpha * SSIM_loss
```

This triggers multiple separate kernel launches (one for L1, one for SSIM, and then more ops for the (1-a)*... + a*... combination)

By fusing this entire logic into a single CUDA kernel, we can save a ton of memory bandwidth and kernel launch overhead.

Here are the benchmark results for forward + backward time. (Python 3.10, PyTorch 2.1.0+cu118, RTX 4090)

```
benchmarking with shape [3, 1080, 1920]
l1 + fused_ssim Time (forward + backward): 0.8399200439453125 ms
fused_l1_ssim_loss Time (forward + backward): 0.5695652961730957 ms (32.19% faster)

benchmarking with shape [3, 2160, 3840]
l1 + fused_ssim Time (forward + backward): 4.154317378997803 ms
fused_l1_ssim_loss Time (forward + backward): 2.543454170227051 ms (38.78% faster)
```

This operator is highly practical, as the ≈1.6 ms saved per iteration translates to a total **saving of nearly 50 seconds over a typical 30,000-iteration training run at 2160×3840 resolution**, making high-resolution training significantly faster.